### PR TITLE
SPC-1912 - Fix crash on cancel

### DIFF
--- a/src/swift/utils/Operation.swift
+++ b/src/swift/utils/Operation.swift
@@ -46,23 +46,16 @@ public class MCOOperation: NSObjectCompat {
     /** This methods is called on the main thread when the asynchronous operation is finished.
      Needs to be overriden by subclasses.*/
     public func operationCompleted() {
-    
+        
     }
     
     /** Cancel the operation.*/
     public func cancel() {
-        let shouldRelease: Bool
-
-        startedPropertyLock.lock()
-        shouldRelease = _started
-        _started = false
-        startedPropertyLock.unlock()
-
+        // cancel first, because MCOperationQueue.cpp check isCancelled() before call completion
+        // which will call operationCompletedCallback, which causes to access to deallocated object
         nativeInstance.cancel();
-        if shouldRelease {
-            // Unbalanced release
-            Unmanaged<MCOOperation>.passUnretained(self).release()
-        }
+        
+        releaseOnComplete()
     }
     
     internal func start() {
@@ -84,6 +77,7 @@ public class MCOOperation: NSObjectCompat {
         }
         startedPropertyLock.unlock()
     }
+    
 #if os(Android)
     public static func setMainQueue(_ mainQueue: DispatchQueue) {
         CObject.setMainQueue(mainQueue.wrapped)

--- a/src/swift/utils/Operation.swift
+++ b/src/swift/utils/Operation.swift
@@ -93,7 +93,12 @@ public class MCOOperation: NSObjectCompat {
 
 //MARK: C Functions
 public func operationCompletedCallback(ref: UnsafeRawPointer?) {
-    let unmanagedSelf = Unmanaged<MCOOperation>.fromOpaque(ref!)
+    guard let ref = ref else {
+        assert(false)
+        return
+    }
+    
+    let unmanagedSelf = Unmanaged<MCOOperation>.fromOpaque(ref)
     let selfRef = unmanagedSelf.takeUnretainedValue()
     selfRef.operationCompleted()
     selfRef.releaseOnComplete()


### PR DESCRIPTION
Actually, it was fixed in 45eb53f9ddf0dfdc0d64dbc148cca52a88fd6997, when Anton replaced autorelease() with release(), and moved cancel() above release().

I removed code duplication and added a comment to pay attention to race condition problem.