### PR TITLE
SPC-2940 - Fix crash while parsing rfc822

### DIFF
--- a/src/core/renderer/MCHTMLRenderer.cpp
+++ b/src/core/renderer/MCHTMLRenderer.cpp
@@ -332,7 +332,10 @@ static String * htmlForAbstractSinglePart(AbstractPart * part, htmlRendererConte
                 if (data == NULL) {
                     // It may be NULL when mailcore::MessageParser::attachments() is invoked when
                     // when mailcore::MessageParser has been serialized/unserialized.
-                    data = context->rfc822DataCallback->dataForRFC822Part(context->folder, (Attachment *) part);
+                    HTMLRendererRFC822Callback * rfc822DataCallback = context->rfc822DataCallback;
+                    if (rfc822DataCallback != NULL) {
+                        data = rfc822DataCallback->dataForRFC822Part(context->folder, (Attachment *) part);
+                    }
                 }
                 MCAssert(data != NULL);
             }
@@ -356,7 +359,10 @@ static String * htmlForAbstractSinglePart(AbstractPart * part, htmlRendererConte
                 if (data == NULL) {
                     // It may be NULL when mailcore::MessageParser::attachments() is invoked when
                     // when mailcore::MessageParser has been serialized/unserialized.
-                    data = context->rfc822DataCallback->dataForRFC822Part(context->folder, (Attachment *) part);
+                    HTMLRendererRFC822Callback * rfc822DataCallback = context->rfc822DataCallback;
+                    if (rfc822DataCallback != NULL) {
+                        data = rfc822DataCallback->dataForRFC822Part(context->folder, (Attachment *) part);
+                    }
                 }
             }
             if (data == NULL)


### PR DESCRIPTION
@lxbndr , @vs-savchenko 
There is no possibility to download the data in this case (we parse rfc822 from the push notification).
So, we can't pass a callback. I've added a check for the NULL.