### PR TITLE
AB#5337 - Fix windows build with VC 14.27

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   set(linux_libraries ${icu_libraries} pthread uuid)
 elseif(WIN32)
   set(CMAKE_CXX_STANDARD 11)
+  add_compile_definitions(_HAS_CONDITIONAL_EXPLICIT=0)
   set(BUILD_SHARED_LIBS ON)
   set(additional_includes
     "${CMAKE_CURRENT_SOURCE_DIR}/Externals/include"


### PR DESCRIPTION
A workaround for older clang-cl with a newer MSVC runtime. It ships with a C++ compiler that enables conditional explicit from C++20 unconditionally. This already fixed in recent clang version, but Swift toolchain is based on a slightly older clang.

This is the reason of compilation errors like:
```
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.27.29110\include\utility(137,9): error: expected member name or ';' after declaration specifiers
        !_Is_implicitly_default_constructible<_Uty1>::value || !_Is_implicitly_default_constructible<_Uty2>::value)
        ^
```