### PR TITLE
AB#11485 - Update openssl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,12 +221,12 @@ else()
       NAMES openssl/opensslv.h
       PATHS ${additional_includes}
     )
-    find_library(OPENSSL_EAY_LIBRARY
-      NAMES libeay32MD
+    find_library(OPENSSL_CRYPTO_LIBRARY
+      NAMES libcrypto
       PATHS ${additional_lib_searchpath}
     )
 
-    if(NOT OPENSSL_INCLUDE_DIR OR NOT OPENSSL_EAY_LIBRARY)
+    if(NOT OPENSSL_INCLUDE_DIR OR NOT OPENSSL_CRYPTO_LIBRARY)
       message(FATAL_ERROR "ERROR: Could not find OpenSSL")
     else()
       message(STATUS "Found OpenSSL")

--- a/build-windows/vs2019/libetpan/libetpan.vcxproj
+++ b/build-windows/vs2019/libetpan/libetpan.vcxproj
@@ -98,7 +98,7 @@
     </ClCompile>
     <Link>
       <AdditionalOptions>/DLL %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies>libsasl2.lib;zlib.lib;Ws2_32.lib;ssleay32MDd.lib;libeay32MDd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>sasl2.lib;zlib.lib;Ws2_32.lib;libssl.lib;libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>../../third-party/lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>C;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
@@ -130,7 +130,7 @@
     </ClCompile>
     <Link>
       <AdditionalOptions>/DLL %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies>libsasl2.lib;zlib.lib;Ws2_32.lib;ssleay32MDd.lib;libeay32MDd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>sasl2.lib;zlib.lib;Ws2_32.lib;libssl.lib;libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>../../third-party/lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>C;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
@@ -160,7 +160,7 @@
     </ClCompile>
     <Link>
       <AdditionalOptions>/DLL %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies>libsasl2.lib;zlib.lib;Ws2_32.lib;ssleay32MD.lib;libeay32MD.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>sasl2.lib;zlib.lib;Ws2_32.lib;libssl.lib;libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>../../third-party/lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>C;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -189,7 +189,7 @@
     </ClCompile>
     <Link>
       <AdditionalOptions>/DLL %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies>libsasl2.lib;zlib.lib;Ws2_32.lib;ssleay32MD.lib;libeay32MD.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>sasl2.lib;zlib.lib;Ws2_32.lib;libssl.lib;libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>../../third-party/lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>C;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,7 +82,7 @@ if(WIN32)
                           ${CTEMPLATE_LIBRARY}
                           ${TIDY_LIBRARY}
                           ${LIBXML_LIBRARY}
-                          ${OPENSSL_EAY_LIBRARY}
+                          ${OPENSSL_CRYPTO_LIBRARY}
                           ${ZLIB_LIBRARY}
                           ${ICU4C_UC_LIBRARY}
                           ${ICU4C_IN_LIBRARY}

--- a/src/core/imap/MCIMAPSession.cpp
+++ b/src/core/imap/MCIMAPSession.cpp
@@ -359,6 +359,10 @@ static IndexSet * indexSetFromSet(struct mailimap_set * imap_set)
     return indexSet;
 }
 
+static void setMailStreamSSLContextServerName(mailstream_ssl_context * ssl_context, void * data) {
+	mailstream_ssl_set_server_name(ssl_context, static_cast<char*>(data));
+}
+
 void IMAPSession::init()
 {
     mHostname = NULL;
@@ -673,7 +677,7 @@ void IMAPSession::connect(ErrorCode * pError)
         break;
 
         case ConnectionTypeTLS:
-        r = mailimap_ssl_connect_voip(mImap, MCUTF8(mHostname), mPort, isVoIPEnabled());
+        r = mailimap_ssl_connect_voip_with_callback(mImap, MCUTF8(mHostname), mPort, isVoIPEnabled(), setMailStreamSSLContextServerName, const_cast<void*>(static_cast<const void*>(MCUTF8(mHostname))));
         MCLog("ssl connect %s %u %u", MCUTF8(mHostname), mPort, r);
         if (hasError(r)) {
             MCLog("connect error %i", r);


### PR DESCRIPTION
OpenSSL 1.1.1i was prebuild and added to repository as a binary
SASL ( which depends on OpenSSL) was rebuild with new OpenSSL and added to repository as a binary
As new OpenSSL works with SNI, so we need to provide target servername, fortunetelly libetpan already incorporated this, so on mailcore side we only need to call corresponding method of etpan